### PR TITLE
Fix Pagination Warning in Research Dashboard

### DIFF
--- a/research_dashboard/views.py
+++ b/research_dashboard/views.py
@@ -54,7 +54,7 @@ class DashboardView(View):
             active_phases=Count('phases', filter=Q(phases__completed=False)),
             completed_milestones=Count('milestones', filter=Q(milestones__status='completed')),
             total_milestones=Count('milestones')
-        ).prefetch_related('phases', 'milestones')
+        ).prefetch_related('phases', 'milestones').order_by('-created_at')
 
         # Calculate completion percentage for each project
         today = timezone.now().date()


### PR DESCRIPTION
## Description
This PR fixes the Django warning: "UnorderedObjectListWarning: Pagination may yield inconsistent results with an unordered object_list" that appeared in the ResearchProject queryset pagination.

## Changes Made
- Added explicit `.order_by('-created_at')` to the projects queryset in `DashboardView.get()` after annotations and prefetch_related
- Ensures consistent ordering for pagination results while maintaining all existing functionality

## Technical Details
- The ResearchProject model already had Meta.ordering = ['-created_at']
- However, the ordering was being lost during queryset operations with annotations
- The fix explicitly applies the ordering after all queryset modifications

## Testing
- Verify pagination works consistently across all pages
- Confirm the warning no longer appears in logs
- Check that all existing filters and annotations still work as expected

## Related Issues
- Fixes warning that appeared during development
- Improves reliability of paginated results
